### PR TITLE
docs: archive bytedance/seedance-1-0-lite-t2v

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -306,7 +306,6 @@
     * [Wan 2.7 (Reference-to-Video)](api-references/video-models/alibaba-cloud/wan-2.7-reference-to-video.md)
     * [happyhorse-1-1](api-references/video-models/Alibaba-Cloud/happyhorse-1-1.md)
   * [ByteDance](api-references/video-models/bytedance/README.md)
-    * [Seedance 1.0 Lite (Text-to-Video)](api-references/video-models/bytedance/seedance-1.0-lite-text-to-video.md)
     * [Seedance 1.0 Lite (Image-to-Video)](api-references/video-models/bytedance/seedance-1.0-lite-image-to-video.md)
     * [Seedance 1.0 Pro (Text-to-Video)](api-references/video-models/bytedance/seedance-1.0-pro-text-to-video.md)
     * [Seedance 1.0 Pro (Image-to-Video)](api-references/video-models/bytedance/seedance-1.0-pro-image-to-video.md)
@@ -625,3 +624,7 @@
 
 * [404 Model is deprecated](404-model-is-deprecated.md)
 * [llms.txt](<README (1).md>)
+
+## Archived
+
+* [ByteDance / Seedance 1.0 Lite (Text-to-Video)](api-references/video-models/bytedance/seedance-1.0-lite-text-to-video.md)


### PR DESCRIPTION
Move `seedance-1.0-lite-text-to-video` into the Archived section of SUMMARY.md (model `bytedance/seedance-1-0-lite-t2v` removed from the catalog). Page files kept.