### PR TITLE
docs: hide moonshot/kimi-k2-preview

### DIFF
--- a/docs/api-references/text-models-llm/moonshot/kimi-k2-preview.md
+++ b/docs/api-references/text-models-llm/moonshot/kimi-k2-preview.md
@@ -1,4 +1,5 @@
 ---
+noIndex: true
 hidden: true
 ---
 


### PR DESCRIPTION
Set `hidden: true` and `noIndex: true` in `kimi-k2-preview` page frontmatter (model `moonshot/kimi-k2-preview` removed from the catalog).