### PR TITLE
docs: fix Ernie and Longcat response model examples

### DIFF
--- a/docs/api-references/text-models-llm/Meituan/longcat-2.0.json
+++ b/docs/api-references/text-models-llm/Meituan/longcat-2.0.json
@@ -1399,7 +1399,7 @@
                     "model": {
                       "type": "string",
                       "description": "The model used for the chat completion.",
-                      "example": "gpt-4o-2024-08-06"
+                      "example": "meituan/longcat-2.0"
                     },
                     "usage": {
                       "type": "object",

--- a/docs/api-references/text-models-llm/Meituan/longcat-2.0.md
+++ b/docs/api-references/text-models-llm/Meituan/longcat-2.0.md
@@ -131,7 +131,7 @@ main();
   "id": "chatcmpl-69e739eef31cfb42680c11fa",
   "object": "chat.completion",
   "created": 1776761328,
-  "model": "kimi-k2.7-code-highspeed",
+  "model": "meituan/longcat-2.0",
   "choices": [
     {
       "index": 0,

--- a/docs/api-references/text-models-llm/baidu/ernie-5.0.json
+++ b/docs/api-references/text-models-llm/baidu/ernie-5.0.json
@@ -1532,7 +1532,7 @@
                     "model": {
                       "type": "string",
                       "description": "The model used for the chat completion.",
-                      "example": "gpt-4o-2024-08-06"
+                      "example": "baidu/ernie-5.0"
                     },
                     "usage": {
                       "type": "object",

--- a/docs/api-references/text-models-llm/baidu/ernie-5.0.md
+++ b/docs/api-references/text-models-llm/baidu/ernie-5.0.md
@@ -126,7 +126,7 @@ console.log(await response.json());
       "logprobs": null
     }
   ],
-  "model": "gpt-4o-2024-08-06",
+  "model": "baidu/ernie-5.0",
   "usage": {
     "prompt_tokens": 137,
     "completion_tokens": 914,


### PR DESCRIPTION
Replace stale copied response model examples in Ernie 5.0 and Longcat 2.0 docs/OpenAPI schemas with their actual model IDs.