### PR TITLE
Add API Key Usage docs for /v2/usage and /v2/usage/detail

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -14,6 +14,7 @@
 * [🟡 Service Endpoints](api-references/service-endpoints/README.md)
   * [Account Balance](api-references/service-endpoints/account-balance.md)
   * [API Key Management](api-references/service-endpoints/api-key-management.md)
+  * [API Key Usage](api-references/service-endpoints/api-key-usage.md)
   * [Complete Model List](api-references/service-endpoints/complete-model-list.md)
 * [All Model IDs](api-references/model-database.md)
 * [Text Models (LLM)](api-references/text-models-llm/README.md)

--- a/docs/api-references/service-endpoints/api-key-usage.md
+++ b/docs/api-references/service-endpoints/api-key-usage.md
@@ -1,0 +1,65 @@
+# API Key Usage
+
+Query how much a given API key spent over a period of time.\
+To make a request, you only need your AIMLAPI key obtained from your [account dashboard](https://aimlapi.com/app/keys).
+
+Both endpoints take the same parameters and differ only in what they return: `/v2/usage/detail` adds a per-model breakdown.
+
+## Choosing the time window
+
+Pass **either** `period` **or** both `start` and `end` — not both at once:
+
+* `period` is relative — `24h`, `7d`, that is a positive integer followed by `h` or `d`.
+* `start` and `end` are absolute ISO-8601 timestamps.
+
+The window cannot exceed **92 days**. For a longer report, request several windows and add them up.
+
+{% hint style="info" %}
+A timestamp without a UTC offset is read as **UTC**, not as your local time. Pass an explicit offset (`2026-07-01T00:00:00+03:00`) if you mean something else.
+
+The response always echoes `start` and `end` resolved to UTC, so you can see exactly which window was measured.
+{% endhint %}
+
+## Choosing the key
+
+| Your key | `key_prefix` | Result |
+| ---------------- | ------------------------ | ---------------- |
+| any key | omitted | its own spend |
+| management key | provided | that key's spend |
+| regular key | provided, its own prefix | its own spend |
+| regular key | provided, another prefix | `403` |
+
+Any key can read its own spend. Reading the spend of a **different** key requires a management key.
+
+## Get key usage
+
+Returns the total spend for a key over the requested window.
+
+{% openapi-operation spec="usage-v2" path="/v2/usage" method="get" %}
+[OpenAPI usage-v2](https://raw.githubusercontent.com/aimlapi/api-docs/refs/heads/main/docs/api-references/service-endpoints/usage-v2.json)
+{% endopenapi-operation %}
+
+## Get detailed key usage
+
+Returns the same total plus a per-model breakdown, sorted by spend.
+
+{% openapi-operation spec="usage-detail-v2" path="/v2/usage/detail" method="get" %}
+[OpenAPI usage-detail-v2](https://raw.githubusercontent.com/aimlapi/api-docs/refs/heads/main/docs/api-references/service-endpoints/usage-detail-v2.json)
+{% endopenapi-operation %}
+
+## Good to know
+
+* **`spend` is the authoritative total.** In the detailed response it is computed from the total rather than by adding up `models`, so the two can differ by a few nano-dollars. That is expected.
+* **Unfinished work is not counted.** A video generation that is still running is excluded until it completes.
+* **This is not your balance.** These endpoints answer "what did this key cost", which is useful for cost attribution and budgeting. For your current balance use [Account Balance](account-balance.md).
+* **Polling?** Prefer `period`. Responses are cached briefly per exact window, and a hand-built timestamp that changes on every call never reuses that cache.
+
+## Errors
+
+| Code | Meaning |
+| ----- | ---------------------------------------------------------------------------------------------------------------------- |
+| `400` | No window given, both window forms given at once, a malformed date or period, `end` earlier than `start`, or over 92 days |
+| `401` | Missing or invalid API key |
+| `403` | A regular key asked for another key's prefix |
+| `404` | The prefix does not belong to your account |
+| `429` | Too many requests |

--- a/docs/api-references/service-endpoints/usage-detail-v2.json
+++ b/docs/api-references/service-endpoints/usage-detail-v2.json
@@ -1,0 +1,164 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "AIML API",
+    "version": "1.0.0"
+  },
+  "servers": [
+    {
+      "url": "https://api.aimlapi.com"
+    }
+  ],
+  "paths": {
+    "/v2/usage/detail": {
+      "get": {
+        "operationId": "_v2_usage_detail",
+        "parameters": [
+          {
+            "name": "period",
+            "in": "query",
+            "required": false,
+            "description": "Relative window: a positive integer followed by `h` or `d`, for example `24h` or `7d`. Provide either `period` or both `start` and `end`, never both.",
+            "schema": {
+              "type": "string",
+              "example": "7d"
+            }
+          },
+          {
+            "name": "start",
+            "in": "query",
+            "required": false,
+            "description": "Window start, ISO-8601. A value without a UTC offset is read as UTC. Must be used together with `end`.",
+            "schema": {
+              "type": "string",
+              "example": "2026-07-01T00:00:00Z"
+            }
+          },
+          {
+            "name": "end",
+            "in": "query",
+            "required": false,
+            "description": "Window end, ISO-8601. Must not be earlier than `start`, and the window must not exceed 92 days.",
+            "schema": {
+              "type": "string",
+              "example": "2026-07-28T00:00:00Z"
+            }
+          },
+          {
+            "name": "key_prefix",
+            "in": "query",
+            "required": false,
+            "description": "Prefix of the key to report on. Omit it to get the spend of the key you are authenticating with. Reporting on a different key requires a management key.",
+            "schema": {
+              "type": "string",
+              "example": "abcd1234"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "api_key_prefix": {
+                      "type": "string",
+                      "nullable": true,
+                      "description": "The requested key prefix, or null when it was omitted and the answer is your own key's spend.",
+                      "example": "abcd1234"
+                    },
+                    "start": {
+                      "type": "string",
+                      "description": "Window start, resolved to UTC.",
+                      "example": "2026-07-20T22:15:00.000Z"
+                    },
+                    "end": {
+                      "type": "string",
+                      "description": "Window end, resolved to UTC.",
+                      "example": "2026-07-27T22:15:00.000Z"
+                    },
+                    "spend": {
+                      "type": "number",
+                      "description": "Total spend for the key over the window, in USD. This is the authoritative total: it is computed from the total, not by adding up models, so it can differ from that sum by a few nano-dollars.",
+                      "example": 12.3456
+                    },
+                    "currency": {
+                      "type": "string",
+                      "description": "Spend currency (always USD).",
+                      "example": "USD"
+                    },
+                    "requests": {
+                      "type": "integer",
+                      "description": "Number of charged requests in the window.",
+                      "example": 842
+                    },
+                    "models": {
+                      "type": "array",
+                      "description": "Per-model breakdown, highest spend first.",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "model": {
+                            "type": "string",
+                            "description": "Model name.",
+                            "example": "openai/gpt-5"
+                          },
+                          "spend": {
+                            "type": "number",
+                            "description": "Spend for this model, in USD.",
+                            "example": 8.12
+                          },
+                          "requests": {
+                            "type": "integer",
+                            "description": "Charged requests for this model.",
+                            "example": 500
+                          }
+                        },
+                        "required": ["model", "spend", "requests"]
+                      }
+                    }
+                  },
+                  "required": [
+                    "api_key_prefix",
+                    "start",
+                    "end",
+                    "spend",
+                    "currency",
+                    "requests",
+                    "models"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "x-hideTryItPanel": true,
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "source": "curl -L \\\n  --request GET \\\n  --url 'https://api.aimlapi.com/v2/usage/detail?key_prefix=abcd1234&period=7d' \\\n  --header 'Authorization: Bearer <YOUR_AIMLAPI_MANAGEMENT_KEY>'"
+          },
+          {
+            "lang": "JavaScript",
+            "source": "async function main() {\n  const url = new URL(\"https://api.aimlapi.com/v2/usage/detail\");\n  url.searchParams.set(\"key_prefix\", \"abcd1234\");\n  url.searchParams.set(\"period\", \"7d\");\n\n  const response = await fetch(url, {\n    headers: {\n      \"Authorization\": \"Bearer <YOUR_AIMLAPI_MANAGEMENT_KEY>\",\n    },\n  });\n\n  const data = await response.json();\n  console.log(JSON.stringify(data, null, 2));\n}\n\nmain();"
+          },
+          {
+            "lang": "Python",
+            "source": "import requests\nimport json\n\ndef main():\n    response = requests.get(\n        \"https://api.aimlapi.com/v2/usage/detail\",\n        headers={\n            # Insert your AIML API management key instead of <YOUR_AIMLAPI_MANAGEMENT_KEY>:\n            \"Authorization\": \"Bearer <YOUR_AIMLAPI_MANAGEMENT_KEY>\",\n        },\n        params={\"key_prefix\": \"abcd1234\", \"period\": \"7d\"}\n    )\n\n    data = response.json()\n    print(json.dumps(data, indent=2, ensure_ascii=False))\n\nif __name__ == \"__main__\":\n    main()"
+          }
+        ]
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "access-token": {
+        "scheme": "bearer",
+        "bearerFormat": "<YOUR_AIMLAPI_KEY>",
+        "type": "http",
+        "description": "Bearer key"
+      }
+    }
+  }
+}

--- a/docs/api-references/service-endpoints/usage-v2.json
+++ b/docs/api-references/service-endpoints/usage-v2.json
@@ -1,0 +1,138 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "AIML API",
+    "version": "1.0.0"
+  },
+  "servers": [
+    {
+      "url": "https://api.aimlapi.com"
+    }
+  ],
+  "paths": {
+    "/v2/usage": {
+      "get": {
+        "operationId": "_v2_usage",
+        "parameters": [
+          {
+            "name": "period",
+            "in": "query",
+            "required": false,
+            "description": "Relative window: a positive integer followed by `h` or `d`, for example `24h` or `7d`. Provide either `period` or both `start` and `end`, never both.",
+            "schema": {
+              "type": "string",
+              "example": "24h"
+            }
+          },
+          {
+            "name": "start",
+            "in": "query",
+            "required": false,
+            "description": "Window start, ISO-8601. A value without a UTC offset is read as UTC. Must be used together with `end`.",
+            "schema": {
+              "type": "string",
+              "example": "2026-07-01T00:00:00Z"
+            }
+          },
+          {
+            "name": "end",
+            "in": "query",
+            "required": false,
+            "description": "Window end, ISO-8601. Must not be earlier than `start`, and the window must not exceed 92 days.",
+            "schema": {
+              "type": "string",
+              "example": "2026-07-28T00:00:00Z"
+            }
+          },
+          {
+            "name": "key_prefix",
+            "in": "query",
+            "required": false,
+            "description": "Prefix of the key to report on. Omit it to get the spend of the key you are authenticating with. Reporting on a different key requires a management key.",
+            "schema": {
+              "type": "string",
+              "example": "abcd1234"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "api_key_prefix": {
+                      "type": "string",
+                      "nullable": true,
+                      "description": "The requested key prefix, or null when it was omitted and the answer is your own key's spend.",
+                      "example": "abcd1234"
+                    },
+                    "start": {
+                      "type": "string",
+                      "description": "Window start, resolved to UTC.",
+                      "example": "2026-07-26T22:15:00.000Z"
+                    },
+                    "end": {
+                      "type": "string",
+                      "description": "Window end, resolved to UTC.",
+                      "example": "2026-07-27T22:15:00.000Z"
+                    },
+                    "spend": {
+                      "type": "number",
+                      "description": "Total spend for the key over the window, in USD.",
+                      "example": 13.704199
+                    },
+                    "currency": {
+                      "type": "string",
+                      "description": "Spend currency (always USD).",
+                      "example": "USD"
+                    },
+                    "requests": {
+                      "type": "integer",
+                      "description": "Number of charged requests in the window.",
+                      "example": 9643
+                    }
+                  },
+                  "required": [
+                    "api_key_prefix",
+                    "start",
+                    "end",
+                    "spend",
+                    "currency",
+                    "requests"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "x-hideTryItPanel": true,
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "source": "curl -L \\\n  --request GET \\\n  --url 'https://api.aimlapi.com/v2/usage?period=24h' \\\n  --header 'Authorization: Bearer <YOUR_AIMLAPI_KEY>'"
+          },
+          {
+            "lang": "JavaScript",
+            "source": "async function main() {\n  const response = await fetch(\"https://api.aimlapi.com/v2/usage?period=24h\", {\n    headers: {\n      \"Authorization\": \"Bearer <YOUR_AIMLAPI_KEY>\",\n    },\n  });\n\n  const data = await response.json();\n  console.log(JSON.stringify(data, null, 2));\n}\n\nmain();"
+          },
+          {
+            "lang": "Python",
+            "source": "import requests\nimport json\n\ndef main():\n    response = requests.get(\n        \"https://api.aimlapi.com/v2/usage\",\n        headers={\n            # Insert your AIML API Key instead of <YOUR_AIMLAPI_KEY>:\n            \"Authorization\": \"Bearer <YOUR_AIMLAPI_KEY>\",\n        },\n        params={\"period\": \"24h\"}\n    )\n\n    data = response.json()\n    print(json.dumps(data, indent=2, ensure_ascii=False))\n\nif __name__ == \"__main__\":\n    main()"
+          }
+        ]
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "access-token": {
+        "scheme": "bearer",
+        "bearerFormat": "<YOUR_AIMLAPI_KEY>",
+        "type": "http",
+        "description": "Bearer key"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Documents two new service endpoints that report how much a given API key spent over a period:

```
GET /v2/usage
GET /v2/usage/detail
```

Same parameters for both; `detail` adds a per-model breakdown.

## What's here

| File | |
| --- | --- |
| `service-endpoints/api-key-usage.md` | the page |
| `service-endpoints/usage-v2.json` | OpenAPI spec for `/v2/usage` |
| `service-endpoints/usage-detail-v2.json` | OpenAPI spec for `/v2/usage/detail` |
| `SUMMARY.md` | entry under Service Endpoints, after API Key Management |

Follows the **Account Balance** layout — short prose plus one `{% openapi-operation %}` block per operation — with cURL / JavaScript / Python samples in each spec, matching `billing-v2.json`.

One deviation from the billing specs: these use `parameters` rather than a placeholder `requestBody`, because these endpoints genuinely take query parameters and readers need to see them.

## What the page emphasises

The three things a reader will otherwise get wrong:

- **`period` or `start`+`end`, never both**, and the window is capped at 92 days.
- **A timestamp with no offset is read as UTC**, not local time. The response echoes `start`/`end` resolved to UTC so the measured window is never ambiguous.
- **Which key may read which key.** Any key reads its own spend; reading a *different* key's spend requires a management key, and a regular key asking for someone else's prefix gets a `403`. That is a table on the page.

Plus a short "Good to know" section: `spend` is the authoritative total (the per-model rows can differ from it by nano-dollars), in-flight generations are not counted until they finish, this is cost rather than balance (with a link to Account Balance), and `period` is the right choice when polling.

## Checks

Both JSON specs parse; every `spec=` id resolves to a file that exists and declares the path the block references; both raw.githubusercontent links point at files added in this PR; the relative link to `account-balance.md` resolves; all three Python samples compile.
