### PR TITLE
Add the required response description to the usage OpenAPI specs

### DIFF
--- a/docs/api-references/service-endpoints/usage-detail-v2.json
+++ b/docs/api-references/service-endpoints/usage-detail-v2.json
@@ -57,6 +57,7 @@
         ],
         "responses": {
           "200": {
+            "description": "Total spend for the key over the requested window, with a per-model breakdown.",
             "content": {
               "application/json": {
                 "schema": {
@@ -115,7 +116,11 @@
                             "example": 500
                           }
                         },
-                        "required": ["model", "spend", "requests"]
+                        "required": [
+                          "model",
+                          "spend",
+                          "requests"
+                        ]
                       }
                     }
                   },

--- a/docs/api-references/service-endpoints/usage-v2.json
+++ b/docs/api-references/service-endpoints/usage-v2.json
@@ -57,6 +57,7 @@
         ],
         "responses": {
           "200": {
+            "description": "Total spend for the key over the requested window.",
             "content": {
               "application/json": {
                 "schema": {


### PR DESCRIPTION
## Summary

After registering `usage-v2` and `usage-detail-v2` in GitBook, both came back `processingState=complete` but with one validation error each:

```
/paths/~1v2~1usage/get/responses/200
  oneOf must match exactly one schema in oneOf
```

OpenAPI 3.0 requires `description` on a Response Object. Without it the object matches neither `Response` nor `Reference`, so the union fails. Adds it to the 200 of both specs.

## Impact

Cosmetic — the pages already render. For comparison, `billing-v2` and `billing-detail-v2` each carry **ten** processing errors (from their placeholder `requestBody` with `"type": "–"`) and render fine. Mine had one. Still worth fixing rather than leaving a knowingly invalid spec.

After this merges, re-`PUT` both slugs through the GitBook API so it refetches from `main`.