### PR TITLE
Document the model catalogue API (`GET /v1/models`)

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -13,6 +13,7 @@
 
 * [🟡 Service Endpoints](api-references/service-endpoints/README.md)
   * [Account Balance](api-references/service-endpoints/account-balance.md)
+  * [Model Catalogue API](api-references/service-endpoints/models-catalogue.md)
   * [API Key Management](api-references/service-endpoints/api-key-management.md)
   * [API Key Usage](api-references/service-endpoints/api-key-usage.md)
   * [Complete Model List](api-references/service-endpoints/complete-model-list.md)

--- a/docs/api-references/service-endpoints/models-catalogue.md
+++ b/docs/api-references/service-endpoints/models-catalogue.md
@@ -1,0 +1,143 @@
+---
+icon: list-tree
+---
+
+# Model Catalogue API
+
+## List models
+
+`GET /v1/models` returns the live catalogue. It is the machine-readable source for which models exist, what they are called, what they can do, and what they cost — use it instead of scraping the model pages.
+
+By default each entry carries only its identity. Pricing, modalities and capabilities are opt-in, so the default response stays small:
+
+```bash
+curl https://api.aimlapi.com/v1/models
+```
+
+```json
+{
+  "object": "list",
+  "data": [
+    {
+      "id": "deepgram/aura-2",
+      "aliases": ["aura-2", "aura-2-helena-en", "deepgram/aura-2-helena-en"],
+      "type": "internal/text-to-speech",
+      "info": { "name": "Aura-2", "developer": "Deepgram" },
+      "tags": ["playground:tts"]
+    }
+  ]
+}
+```
+
+{% openapi-operation spec="models-catalogue" path="/v1/models" method="get" %}
+[OpenAPI models-catalogue](https://raw.githubusercontent.com/aimlapi/api-docs/refs/heads/main/docs/service-endpoints/models-catalogue.json)
+{% endopenapi-operation %}
+
+## Asking for more per model
+
+`include` attaches optional sections. Combine them freely, comma-separated:
+
+```bash
+curl 'https://api.aimlapi.com/v1/models?include=pricing'
+curl 'https://api.aimlapi.com/v1/models?include=pricing,capabilities'
+curl 'https://api.aimlapi.com/v1/models?include=all'
+```
+
+| Value | Adds |
+| --- | --- |
+| `pricing` | the `pricing` block — rates, units, price bands |
+| `modalities` | which input and output modalities the model handles |
+| `capabilities` | declared capabilities, e.g. `image_to_video` |
+| `all` | every section. `?details=true` is a synonym |
+
+Unknown values are ignored rather than rejected, so a typo returns a valid response with that section missing.
+
+## Filtering
+
+Every filter below narrows *which models* come back. They are independent of `include`, so you can filter on capabilities without asking for the capabilities section.
+
+| Parameter | Keeps models that… |
+| --- | --- |
+| `id` | match this id **or carry it as an alias** |
+| `type` | are served through this endpoint type |
+| `tags` | carry this tag, e.g. `playground:video` |
+| `modalities` | have it among input **or** output modalities |
+| `input_modalities` | accept this input modality |
+| `output_modalities` | produce this output modality |
+| `capabilities` | declare this capability |
+
+Rules that apply to all of them:
+
+* **Several values, one parameter — OR.** `?capabilities=text_to_video,image_to_video` returns models that do either.
+* **Several parameters — AND.** `?output_modalities=video&capabilities=audio_generation` returns models that do both.
+* Values are **case-insensitive**, and may be given comma-separated (`?tags=a,b`) or repeated (`?tags=a&tags=b`). Both forms merge.
+* An omitted parameter filters nothing.
+
+```bash
+# every model that turns an image into video
+curl 'https://api.aimlapi.com/v1/models?capabilities=image_to_video'
+
+# what one specific model costs — a few kilobytes instead of the whole catalogue
+curl 'https://api.aimlapi.com/v1/models?id=deepgram/aura-2&include=pricing'
+```
+
+## Checking whether a model is still available
+
+Match against **`id` and `aliases` together**. A model may be published under a canonical id while the name you integrated against lives on as an alias — the alias keeps working, but it is not the `id` any more, so an `id`-only comparison reports a live model as gone.
+
+```js
+const res = await fetch('https://api.aimlapi.com/v1/models');
+const { data } = await res.json();
+
+const byName = new Map();
+for (const model of data) {
+  byName.set(model.id, model.id);
+  for (const alias of model.aliases ?? []) byName.set(alias, model.id);
+}
+
+const canonical = byName.get(myModelId); // undefined ⇒ genuinely unavailable
+```
+
+The same map de-duplicates your list: two names resolving to one canonical id are one model, not two.
+
+## Reading prices
+
+With `?include=pricing`, each model carries a `pricing` block. Read `kind` first:
+
+| `kind` | What it means |
+| --- | --- |
+| `fixed` | one rate per unit, in `units[]` |
+| `variants` | the rate depends on request parameters — `dimensions` names them, `variants[]` quotes a rate per combination |
+| `variable` | the rate cannot be quoted ahead of the request |
+
+**Always read `per` together with `price`.** `price` is the charge for `per` units, and `per` is not the same across models — `1000000` for most token rates, `1000` for some, `1` for per-second and per-megapixel rates. Comparing bare `price` values across models compares different bases and will be wrong by orders of magnitude.
+
+```json
+{
+  "kind": "variants",
+  "dimensions": ["resolution"],
+  "variants": [
+    { "when": { "resolution": "720p" },  "price": 0.39, "unit": "second", "per": 1 },
+    { "when": { "resolution": "1080p" }, "price": 0.65, "unit": "second", "per": 1 }
+  ]
+}
+```
+
+Here a 5-second 1080p generation costs `0.65 × 5 = $3.25`.
+
+Prices are in USD and are what you are charged.
+
+## Caching
+
+Responses carry an `ETag`. Send it back as `If-None-Match` and you get `304 Not Modified` with an empty body when nothing changed:
+
+```bash
+curl -I 'https://api.aimlapi.com/v1/models?include=pricing'
+# etag: W/"1440a0-uH6NONsG/9An5njw3kqMcYY5k8w"
+
+curl -H 'If-None-Match: W/"1440a0-uH6NONsG/9An5njw3kqMcYY5k8w"' \
+     'https://api.aimlapi.com/v1/models?include=pricing'
+# 304
+```
+
+The ETag covers the whole response, so it changes on any catalogue edit — a new model or a reworded description, not only a price change. Treat it as "something moved, re-read and diff", not as a price-change feed.

--- a/docs/service-endpoints/models-catalogue.json
+++ b/docs/service-endpoints/models-catalogue.json
@@ -1,0 +1,223 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "AIML API",
+    "version": "1.0.0"
+  },
+  "servers": [
+    {
+      "url": "https://api.aimlapi.com"
+    }
+  ],
+  "paths": {
+    "/v1/models": {
+      "get": {
+        "operationId": "_v1_models",
+        "summary": "List models",
+        "description": "Returns the model catalogue. By default each entry carries only its identity (`id`, `aliases`, `type`, `info`, `tags`); pricing, modalities and capabilities are opt-in through `include`.",
+        "parameters": [
+          {
+            "name": "include",
+            "in": "query",
+            "required": false,
+            "description": "Comma-separated sections to attach: `pricing`, `modalities`, `capabilities`. `all` (or `details`) attaches every section. Unknown values are ignored rather than rejected.",
+            "schema": {
+              "type": "string",
+              "example": "pricing"
+            }
+          },
+          {
+            "name": "details",
+            "in": "query",
+            "required": false,
+            "description": "Shorthand for `include=all`. Accepts `true` or `1`.",
+            "schema": {
+              "type": "string",
+              "example": "true"
+            }
+          },
+          {
+            "name": "id",
+            "in": "query",
+            "required": false,
+            "description": "Keep only models matching these ids. Matches the canonical `id` **and** every entry in `aliases`, so a legacy name resolves to the model that serves it today.",
+            "schema": {
+              "type": "string",
+              "example": "gpt-5,aura-2-helena-en"
+            }
+          },
+          {
+            "name": "type",
+            "in": "query",
+            "required": false,
+            "description": "Keep only models served through this endpoint type.",
+            "schema": {
+              "type": "string",
+              "example": "openai/chat-completions"
+            }
+          },
+          {
+            "name": "tags",
+            "in": "query",
+            "required": false,
+            "description": "Keep only models carrying these tags.",
+            "schema": {
+              "type": "string",
+              "example": "playground:video"
+            }
+          },
+          {
+            "name": "modalities",
+            "in": "query",
+            "required": false,
+            "description": "Keep only models whose input **or** output modalities include these values.",
+            "schema": {
+              "type": "string",
+              "example": "video"
+            }
+          },
+          {
+            "name": "input_modalities",
+            "in": "query",
+            "required": false,
+            "description": "Keep only models that accept these input modalities.",
+            "schema": {
+              "type": "string",
+              "example": "image"
+            }
+          },
+          {
+            "name": "output_modalities",
+            "in": "query",
+            "required": false,
+            "description": "Keep only models that produce these output modalities.",
+            "schema": {
+              "type": "string",
+              "example": "video"
+            }
+          },
+          {
+            "name": "capabilities",
+            "in": "query",
+            "required": false,
+            "description": "Keep only models declaring these capabilities, e.g. `image_to_video`, `text_to_video`, `audio_generation`.",
+            "schema": {
+              "type": "string",
+              "example": "image_to_video"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The catalogue.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "object": {
+                      "type": "string",
+                      "example": "list"
+                    },
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "description": "Canonical model id. Stable, provider-independent, and the value to store on your side.",
+                            "example": "deepgram/aura-2"
+                          },
+                          "aliases": {
+                            "type": "array",
+                            "description": "Every other name this model answers to. All of them keep working on input, forever.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "example": ["aura-2", "aura-2-helena-en"]
+                          },
+                          "type": {
+                            "type": "string",
+                            "description": "The endpoint this entry is callable through.",
+                            "example": "internal/text-to-speech"
+                          },
+                          "info": {
+                            "type": "object",
+                            "description": "Display metadata: name, developer, description, context length, links."
+                          },
+                          "tags": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            },
+                            "example": ["playground:tts"]
+                          },
+                          "pricing": {
+                            "type": "object",
+                            "description": "Present only with `include=pricing`. See the page body for how to read it.",
+                            "properties": {
+                              "currency": {
+                                "type": "string",
+                                "example": "USD"
+                              },
+                              "kind": {
+                                "type": "string",
+                                "description": "`fixed` — one rate per unit. `variants` — the rate depends on request parameters, listed in `variants`. `variable` — the rate cannot be quoted up front.",
+                                "example": "fixed"
+                              },
+                              "units": {
+                                "type": "array",
+                                "description": "Rate lines. `price` is the charge for `per` units; `per` differs by unit, so never compare `price` across models without it. `price: null` means this line is request-dependent.",
+                                "items": {
+                                  "type": "object"
+                                }
+                              },
+                              "thresholds": {
+                                "type": "array",
+                                "description": "Price bands that kick in above a request size.",
+                                "items": {
+                                  "type": "object"
+                                }
+                              },
+                              "dimensions": {
+                                "type": "array",
+                                "description": "Request parameters the rate depends on.",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "example": ["resolution"]
+                              },
+                              "variants": {
+                                "type": "array",
+                                "description": "One quoted rate per combination of `dimensions`.",
+                                "items": {
+                                  "type": "object"
+                                }
+                              }
+                            }
+                          },
+                          "modalities": {
+                            "type": "object",
+                            "description": "Present only with `include=modalities`."
+                          },
+                          "capabilities": {
+                            "type": "array",
+                            "description": "Present only with `include=capabilities`.",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Why

`GET /v1/models` serves roughly 1.2k requests a day and is documented **nowhere**: no page in this repo, and no Swagger decorators on the handler, so it is absent from Scalar too. Its entire query surface lives in a JSDoc comment in the gateway.

The practical cost: a customer (Help Scout #8265) has been maintaining our prices by hand and polling the deprecated-models HTML page, because nothing told them `?include=pricing` exists — or that `?id=<model>&include=pricing` answers in ~4 KB instead of 1.3 MB.

## What this adds

- `docs/api-references/service-endpoints/models-catalogue.md` — the page
- `docs/service-endpoints/models-catalogue.json` — OpenAPI spec for the operation, same pattern as `billing-balance.json`
- a `SUMMARY.md` entry under Service Endpoints, next to Account Balance

## What it documents

Every parameter, with the semantics verified against production:

- `include` (`pricing` / `modalities` / `capabilities` / `all`) and `details` as its synonym; unknown values ignored, not rejected
- the seven filters — `id`, `type`, `tags`, `modalities`, `input_modalities`, `output_modalities`, `capabilities`
- the matching rules: OR within one parameter, AND across parameters, case-insensitive, comma-separated **or** repeated params both accepted
- filters work independently of `include` — you can filter on capabilities without requesting that section

Plus the two things integrators actually get wrong:

1. **Matching on `id` alone.** A model can be published under a canonical id while the name someone integrated against lives on as an alias — it still serves, but an `id`-only comparison reports it as gone. The page gives the alias-map snippet.
2. **Comparing `price` without `per`.** `per` is `1000000` for most token rates, `1000` for some, `1` for per-second and per-megapixel ones. Comparing bare `price` is wrong by orders of magnitude.

Also covers how to read `pricing.kind` (`fixed` / `variants` / `variable`) and the `ETag` / `If-None-Match` flow, with the caveat that the ETag covers the whole body — it is a "something changed, re-read and diff" signal, not a price feed.

## Checked

The JSON parses. Every example — parameter names, filter behaviour, response shapes, the ETag round-trip, the per-second variant sample — was run against `api.aimlapi.com` rather than written from the source.

## Note

There is no docs preview environment to check this in: the `staging` branch here last moved in May 2025 and is 2331 commits behind `main`, and no GitBook preview is wired to PRs. Rendering is worth a look after merge.